### PR TITLE
Bugfix i valideringen av personnummer

### DIFF
--- a/PersonsokImplementation/PersonsokValidator.cs
+++ b/PersonsokImplementation/PersonsokValidator.cs
@@ -31,7 +31,7 @@ namespace PersonsokImplementation
                 throw new ArgumentOutOfRangeException("PersonId måste bestå utav ett korrekt årtal");
             if(month < 1 || month > 12)
                 throw new ArgumentOutOfRangeException("PersonId måste bestå utav ett korrekt månadstal");
-            if(month < 1 || month > 31 )
+            if(day < 1 || day > 31 )
                 throw new ArgumentOutOfRangeException("PersonId måste bestå utav ett korrekt dagstal");
 
             return IsPersonIdChecksumValid(personId.Substring(2));


### PR DESCRIPTION
Fel variabel används när personnumrets dag kontrolleras, `month` används istället för `day`. Detta är inte jättekritiskt, men det leder till att felaktiga personnummer kan passera kontrollen, till exempel 198507389875 (bland många andra!).