### PR TITLE
Fix the hostname for the SPAR Soap service

### DIFF
--- a/PersonsokImplementation.Tests/PersonsokTest.cs
+++ b/PersonsokImplementation.Tests/PersonsokTest.cs
@@ -20,8 +20,8 @@ namespace Tests
         public void Setup()
         {
             Client = Personsok.CreatePersonsokServiceClient(
-                "https://kt-ext-ws.statenspersonadressregister.se/2021.1/",                 
-                "kt-ext-ws.statenspersonadressregister.se", 
+                "https://test-personsok.statenspersonadressregister.se/2021.1/",
+                "test-personsok.statenspersonadressregister.se",
                 "Kommun_A.p12",
                 "4611510421732432",
                 "DigiCert.pem");

--- a/PersonsokImplementation/Personsok.cs
+++ b/PersonsokImplementation/Personsok.cs
@@ -23,8 +23,8 @@ namespace PersonsokImplementation
         {
             Logger.LogInformation("Demonstration SPAR Personsök program-program version 2021.1");
             PersonsokServiceClient client = CreatePersonsokServiceClient(
-                "https://kt-ext-ws.statenspersonadressregister.se/2021.1/",
-                "kt-ext-ws.statenspersonadressregister.se",
+                "https://test-personsok.statenspersonadressregister.se/2021.1/",
+                "test-personsok.statenspersonadressregister.se",
                 "Kommun_A.p12",
                 "4611510421732432",
                 "DigiCert.pem");


### PR DESCRIPTION
The current hostname kt-ext-ws.statenspersonadressregister.se used in this reference implementation fails with a connection error. It should probably be test-personsok.statenspersonadressregister.se instead as this works fine.